### PR TITLE
Restructuring the code to prevent less API calls

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,20 +1,30 @@
 {
     "Scrobble Data": {
         "scrobble_number": "int64",
+        "username": "str",
         "track_name": "str",
         "track_mbid": "str",
         "date": "datetime64",
-        "duration_seconds": "int64",
+        "track_duration": "int64",
+        "artist_name": "str",
+        "artist_mbid": "str",
+        "album_name": "str",
+        "album_mbid": "str",
+        "album_listeners": "int64",
+        "album_playcount": "int64",
+        "artist_mbid2": "str",
+        "artist_listeners": "int64",
+        "artist_playcount": "int64",
+        "artist_image": "str"
+    },
+    "Artist Data":{
         "artist_name": "str",
         "artist_mbid": "str",
         "artist_listeners": "int64",
         "artist_playcount": "int64",
-        "artist_image": "str",
-        "album_name": "str",
-        "album_mbid": "str",
-        "album_listeners": "int64",
-        "album_playcount": "int64"
+        "artist_image": "str"
     },
+
     "MusicBrainz Data": {
         "artist_country": "str",
         "artist_type": "str",
@@ -24,5 +34,3 @@
         "artist_career_ended": "boolean"
     }
 }
-
-


### PR DESCRIPTION
- Fix the schema to contain all new columns Correcting fetch_album_info function - Was simply returning the duration of the 1st song Now trying to add track name and track mbid to correctly identify the duration

Restructuring the code to prevent less API calls
    - First create the main table exporting 1000 tracks by page
    - Then create a helper table with every unique combination of album/artist (using drop_duplicates())
    - Create a second helper table with every track and its duration for each album/artist
    - Then do a left join of the 2nd helper table to the main table on ['artist_name', 'album_name', 'track_name']
    - Save second helper table to speed up extraction by reducing API calls (include logic to check existing file)
    - Create a third helper table with artist info for every unique artist in the main table
    - Save thir helper table
- Try increasing cap of songs per page to 1000 instead of 200
- Add option of not bringing 'duration' info as it slows a lot the extraction and this way gives a quick option for users to extract data
- Try getting 'duration' of each track, and the artist info, after exporting all the data, and only doing it by unique artist_name / album_name
- Add Username as a column
- Create table with User related data